### PR TITLE
Fix routing paths with fewer parts than a pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## vX.X.X-dev
 
+- Fix routing paths with fewer parts than a pattern.
+
 ## v0.1.3
 
 - Hatter now rejects headers that are over 8KB in total.

--- a/tests/router_test.rs
+++ b/tests/router_test.rs
@@ -102,4 +102,10 @@ fn routing() {
         router.action_for(&mut req).unwrap()(req).to_string(),
         "Mix: of Cargo.toml".to_string()
     );
+
+    let mut req = Request::from_path("/mix/of");
+    assert_eq!(
+        router.action_for(&mut req).unwrap()(req).to_string(),
+        "Parts: mix/of".to_string()
+    );
 }


### PR DESCRIPTION
When a path contains fewer parts than a pattern, `Router.action_for` ignores the latter parts of the pattern. This can cause paths to be routed incorrectly. For example, `/foo` can be routed to the pattern `/foo/bar`.

Fix this by using the maximum of the path and pattern lengths, and failing when the end of one is reached before the other.