### PR TITLE
Changed little inconsistency in manual

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -707,7 +707,7 @@ vial = "0.1"
 `dependencies` needs to list any optional features you want to use,
 however._)
 
-3. Create a `bundle.rs` and call `vial::bundle_assets!()` in it,
+3. Create a `build.rs` in the root of your project and call `vial::bundle_assets!()` in it,
    passing your asset directory as the sole argument:
 
 ```rust


### PR DESCRIPTION
Hello!

I think I found a little inconsistency in the "Bundling assets" section of the manual. 

In the manual it says to create a file `bundle.rs`, however it works only with a file `build.rs`; with `bundle.rs`, the application throws 404 errors when requesting an asset. I also added a hint to place the new file in the project root.

Maybe both things I pointed out are obvious, but as someone new to Rust it took me a little to find the issue, so I wanted to "fix" it :).