### PR TITLE
Fix user agent timeout on empty response body

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -101,6 +101,10 @@ impl Default for Response {
             "Content-Type".to_lowercase(),
             "text/html; charset=utf8".into(),
         );
+        headers.insert(
+            "Content-Length".to_lowercase(),
+            "0".into(),
+        );
 
         Response {
             code: 200,

--- a/tests/response_test.rs
+++ b/tests/response_test.rs
@@ -127,6 +127,7 @@ fn from_code() {
 
     let res = Response::from_code(200);
     assert_eq!(200, res.code());
+    assert_eq!("0", res.header("Content-Length").unwrap());
 
     let res1 = Response::from_code(501);
     let res2 = Response::new().with_code(501);


### PR DESCRIPTION
According to RFC 2616 section 4.4, when no `Content-Length` header is
present, applications may indicate the end of a response body by closing
the connection.

A Vial response with no body, such as `Response::from(200)`, does not
contain a `Content-Length` header. Since Vial also doesn't close the
connection, such a response may cause a user agent to time out.

Fix this by adding `Content-Length: 0` as a default response header.