### PR TITLE
Add remote_addr field to Request

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -37,6 +37,9 @@ impl Span {
 
 /// Contains information about a single request.
 pub struct Request {
+    /// Remote address.
+    remote_addr: String,
+
     /// The raw request.
     buffer: Vec<u8>,
 
@@ -102,6 +105,7 @@ impl Request {
     /// Produce an empty Request.
     pub fn default() -> Request {
         Request {
+            remote_addr: String::new(),
             path: Span::new(),
             method: Span::new(),
             body: Span::new(),
@@ -162,6 +166,16 @@ impl Request {
         }
 
         Ok(req)
+    }
+
+    /// Sets the remote address of the request.
+    pub fn set_remote_addr(&mut self, s: String) {
+        self.remote_addr = s;
+    }
+
+    /// Remote address of the request.
+    pub fn remote_addr(&self) -> &str {
+        &self.remote_addr
     }
 
     /// Path requested, starting with `/` and not including `?query`.

--- a/src/server.rs
+++ b/src/server.rs
@@ -55,7 +55,8 @@ impl Server {
 
     fn handle_request(&self, stream: TcpStream) -> Result<()> {
         let reader = stream.try_clone()?;
-        let req = Request::from_reader(reader)?;
+        let mut req = Request::from_reader(reader)?;
+        req.set_remote_addr(stream.peer_addr()?.to_string());
         self.write_response(stream, req)
     }
 


### PR DESCRIPTION
Wanted to retrieve the IP addresses from the remote hosts that connect to the server, so added a simple implementation for getting the underlying `stream.peer_addr()` to the Request struct. 

One thing I considered is if this should be done at the HTTP-level but since there is no guarantee that the remote host's IP is included in the headers I did this instead. Also debated whether or not it should use SocketStream instead of just String, but this is the simplest solution for now.

Love the project's philosophy, btw! <3