### PR TITLE
fix doc hidden and use non-deprecated compare_exchange

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -67,11 +67,11 @@ impl TypeCache {
 
     #[inline(always)]
     fn lock(&self) {
-        while self.mutex.compare_and_swap(0, 1, Ordering::SeqCst) != 0 {}
+        while self.mutex.compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst) != Ok(0) {}
     }
 
     #[inline(always)]
     fn unlock(&self) {
-        assert!(self.mutex.compare_and_swap(1, 0, Ordering::SeqCst) == 1);
+        assert!(self.mutex.compare_exchange(1, 0, Ordering::SeqCst, Ordering::SeqCst) == Ok(1));
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -300,7 +300,7 @@ impl Request {
 
     /// Parse and decode form POST data into a Hash. Should be called
     /// when this Request is created.
-    #[doc(Hidden)]
+    #[doc(hidden)]
     pub fn parse_form(&mut self) {
         let mut map = HashMap::new();
         for kv in self.body().split('&') {


### PR DESCRIPTION
Hello
This PR only:
- fixes the doc Hidden -> hidden typo.
- Replaces compare_and_swap() with non-deprecated compare_exchange()