### PR TITLE
Resize thread pool and set TcpStream timeout

### DIFF
--- a/examples/cache.rs
+++ b/examples/cache.rs
@@ -35,7 +35,7 @@ impl User {
 }
 
 fn login_required(req: &mut Request) -> Option<Response> {
-    if let Some(_) = req.cache(current_user).as_ref() {
+    if req.cache(current_user).as_ref().is_some() {
         None
     } else {
         Some(Response::redirect_to("/login"))

--- a/examples/modules.rs
+++ b/examples/modules.rs
@@ -1,5 +1,3 @@
-use vial;
-
 mod mods;
 use mods::{blog, wiki};
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -99,18 +99,16 @@ fn last_modified(path: &str) -> Option<String> {
 /// Cleans a path of tricky things like `..` and puts it in a format
 /// we can use in other asset functions.
 pub fn normalize_path(path: &str) -> Option<String> {
-    if let Some(root) = asset_dir() {
-        Some(format!(
+    asset_dir().map(|root| {
+        format!(
             "{}/{}",
             root.trim_end_matches('/'),
             path.trim_start_matches(root)
                 .trim_start_matches('.')
                 .trim_start_matches('/')
                 .replace("..", ".")
-        ))
-    } else {
-        None
-    }
+        )
+    })
 }
 
 /// Have assets been bundled into the binary?

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,7 +52,7 @@ impl fmt::Display for Error {
             f,
             "{}",
             match self {
-                Error::UnknownHTTPMethod(reason) => &reason,
+                Error::UnknownHTTPMethod(reason) => reason,
                 Error::ConnectionClosed => "Connection Closed By Client",
                 Error::ParseVersion => "Error Parsing HTTP Version",
                 Error::ExpectedCRLF => "Expected CRLF in HTTP Request",

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,7 +60,13 @@ impl fmt::Display for Error {
                 Error::ParseHeaderValue => "Error Parsing HTTP Header value",
                 Error::ParseError => "Error Parsing HTTP Request",
                 Error::AssetNotFound(..) => "Can't Find Asset",
-                Error::IO(..) => "io::Error While Parsing HTTP Request",
+                Error::IO(e) => {
+                    if e.kind() == std::io::ErrorKind::WouldBlock {
+                        "io:Error: Thread timeout (std::io::ErrorKind::WouldBlock)"
+                    } else {
+                        "io::Error While Parsing HTTP Request"
+                    }
+                }
                 Error::Other(reason) => &reason,
             }
         )

--- a/src/request.rs
+++ b/src/request.rs
@@ -128,7 +128,7 @@ impl Request {
                 return Err(Error::ConnectionClosed);
             }
             buffer.extend_from_slice(&read_buf[..n]);
-            match http_parser::parse(mem::replace(&mut buffer, vec![]))? {
+            match http_parser::parse(std::mem::take(&mut buffer))? {
                 http_parser::Status::Complete(req) => break req,
                 http_parser::Status::Partial(b) => {
                     let _ = mem::replace(&mut buffer, b);
@@ -411,7 +411,7 @@ impl Request {
         T: Send + Sync + 'static,
     {
         self.cache.get().unwrap_or_else(|| {
-            self.cache.set(fun(&self));
+            self.cache.set(fun(self));
             self.cache.get().unwrap()
         })
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -304,7 +304,7 @@ impl Response {
         }
         match fs::File::open(path) {
             Ok(file) => {
-                self.set_header("ETag", &asset::etag(path).as_ref());
+                self.set_header("ETag", asset::etag(path).as_ref());
                 self.set_header("Content-Type", util::content_type(path));
                 self.set_header("Content-Length", &util::file_size(path).to_string());
                 self.with_reader(Box::new(BufReader::new(file)))

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,22 +4,23 @@ use {
         io::Write,
         net::{TcpListener, TcpStream, ToSocketAddrs},
         sync::{Arc, Mutex},
+        time::Duration
     },
     threadpool::ThreadPool,
 };
 
-const MAX_CONNECTIONS: usize = 10;
+const INITIAL_THREADS: usize = 10;
+const MAXIMUM_THREADS: usize = 400;
 
 /// Starts a new Vial server. Should always be invoked via the
 /// [`vial::run!()`](macro.run.html) macro, since there is some setup
 /// that needs to happen.
 #[doc(hidden)]
 pub fn run<T: ToSocketAddrs>(addr: T, router: Router, banner: Option<&str>) -> Result<()> {
-    let pool = ThreadPool::new(MAX_CONNECTIONS);
+    let mut pool = ThreadPool::new(INITIAL_THREADS);
     let listener = TcpListener::bind(&addr)?;
     let addr = listener.local_addr()?;
     let server = Arc::new(Server::new(router));
-
     #[cfg(feature = "state")]
     eprintln!("! vial feature `state` is now built-in. You can safely remove it.");
 
@@ -32,6 +33,20 @@ pub fn run<T: ToSocketAddrs>(addr: T, router: Router, banner: Option<&str>) -> R
     }
 
     for stream in listener.incoming() {
+        // if all threads are active, extend by one
+        if pool.active_count() == pool.max_count() && pool.max_count() < MAXIMUM_THREADS {
+            pool.set_num_threads(pool.max_count() + 1);
+        }
+
+        // tldr: if total thread count is significantly more than the current load,
+        // drop the number of total threads to just double the current load.
+        // these constants may need tweaking to avoid constant resizing under fluctuating load,
+        // but a 10x fluctuation in load should probably trigger resizing.
+        if pool.max_count() > 10 * pool.active_count() && pool.max_count() > INITIAL_THREADS && pool.active_count() != 0 {
+            pool.set_num_threads(pool.active_count() * 2);
+        }
+
+
         let server = server.clone();
         let stream = stream?;
         pool.execute(move || {
@@ -55,6 +70,10 @@ impl Server {
 
     fn handle_request(&self, stream: TcpStream) -> Result<()> {
         let reader = stream.try_clone()?;
+
+        //discard because: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.set_read_timeout
+        let _ = reader.set_read_timeout(Some(Duration::from_millis(1000))); 
+
         let req = Request::from_reader(reader)?;
         self.write_response(stream, req)
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,7 +4,7 @@ use {
         io::Write,
         net::{TcpListener, TcpStream, ToSocketAddrs},
         sync::{Arc, Mutex},
-        time::Duration
+        time::Duration,
     },
     threadpool::ThreadPool,
 };
@@ -42,10 +42,12 @@ pub fn run<T: ToSocketAddrs>(addr: T, router: Router, banner: Option<&str>) -> R
         // drop the number of total threads to just double the current load.
         // these constants may need tweaking to avoid constant resizing under fluctuating load,
         // but a 10x fluctuation in load should probably trigger resizing.
-        if pool.max_count() > 10 * pool.active_count() && pool.max_count() > INITIAL_THREADS && pool.active_count() != 0 {
+        if pool.max_count() > 10 * pool.active_count()
+            && pool.max_count() > INITIAL_THREADS
+            && pool.active_count() != 0
+        {
             pool.set_num_threads(pool.active_count() * 2);
         }
-
 
         let server = server.clone();
         let stream = stream?;
@@ -72,7 +74,7 @@ impl Server {
         let reader = stream.try_clone()?;
 
         //discard because: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.set_read_timeout
-        let _ = reader.set_read_timeout(Some(Duration::from_millis(1000))); 
+        let _ = reader.set_read_timeout(Some(Duration::from_millis(1000)));
 
         let req = Request::from_reader(reader)?;
         self.write_response(stream, req)


### PR DESCRIPTION
This fixes the trivial attack of slowloris'ing 10 threads and holding them open forever. 
1. the thread count is dynamic (up to 400 threads in my example but that's not a hard limit and depends on use case; it also rescales back down based on demand)
2. the stream is killed after one second (also depends on use case)

Basically just proposing an idea that the thread pool be resized. :)