### PR TITLE
patch window based tests

### DIFF
--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -5,10 +5,11 @@ use {
         env,
         fs::{self, File},
         io::Write,
-        os::unix,
         path::{Path, PathBuf},
     },
 };
+#[cfg(target_family = "unix")]
+use std::os::unix;
 
 /// You should use the
 /// [`vial::bundle_assets!()`](macro.bundle_assets.html) macro instead

--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -82,7 +82,8 @@ fn files_in_dir(path: &str) -> Result<Vec<PathBuf>> {
         let path = entry.path();
         let meta = fs::metadata(&path)?;
         if meta.is_dir() {
-            files.extend_from_slice(&files_in_dir(path.to_str().unwrap_or("bad"))?);
+            let dir = path.to_string_lossy() + "/";
+            files.extend_from_slice(&files_in_dir(dir.as_ref())?);
         } else {
             files.push(path);
         }

--- a/tests/util_test.rs
+++ b/tests/util_test.rs
@@ -57,7 +57,13 @@ fn http_current_date() {
 
 #[test]
 fn file_size() {
-    assert_eq!(1052, util::file_size("LICENSE-MIT"));
-    assert_eq!(25161, util::file_size("tests/assets/rfcs/rfc1288.txt"));
+    #[cfg(target_family = "windows")] {
+        assert_eq!(1072, util::file_size("LICENSE-MIT"));
+        assert_eq!(25835, util::file_size("tests/assets/rfcs/rfc1288.txt"));
+    }
+    #[cfg(target_family = "unix")] {
+        assert_eq!(1052, util::file_size("LICENSE-MIT"));
+        assert_eq!(25161, util::file_size("tests/assets/rfcs/rfc1288.txt"));
+    }
     assert_eq!(0, util::file_size("LICENSE-MADE-UP"));
 }


### PR DESCRIPTION
Fixed an issue where PathBuf would associate a windows-based path separator when programmatically associating a subpath but keep a Unix-based separator when it's defined. This was done by forcing the use of the Unix separator.

Set a configuration option to change the file sizes based on OS.

These would be the best solutions I have so far to the items I reported in Issue #13  