### PR TITLE
Add remote addr (ip) example

### DIFF
--- a/examples/ip.rs
+++ b/examples/ip.rs
@@ -1,0 +1,13 @@
+use vial::prelude::*;
+
+routes! {
+    GET "/" => get_ip;
+}
+
+fn get_ip(req: Request) -> impl Responder {
+    req.remote_addr().to_string()
+}
+
+fn main() {
+    run!().unwrap();
+}


### PR DESCRIPTION
Hiya!

Made a quick example for using the remote addr field that was added before. While not particularly interesting from a code perspective it is useful since if you are hosting that particular example you can use it as a way to check what your external IP is. I just kind of think it is neat. :P

Name of the example is `ip` but that may be a bit too generic? Idk.