### PR TITLE
Add HTTP mocking functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ json_nano = ['nanoserde']
 state = []
 cookies = ['cookie2']
 sessions = ['cookies', 'short-crypt']
+mock = []
 default = []
 
 [dependencies]
@@ -84,3 +85,6 @@ serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 nanoserde = { version = "0.1.29", optional = true }
 short-crypt = { version = "1.0.27", optional = true }
+
+[dev-dependencies]
+minreq = { version = "2.6.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ json_nano = ['nanoserde']
 state = []
 cookies = ['cookie2']
 sessions = ['cookies', 'short-crypt']
-mock = []
 default = []
 
 [dependencies]

--- a/examples/mocking.rs
+++ b/examples/mocking.rs
@@ -1,0 +1,23 @@
+use minreq;
+use vial::{routes, run_once};
+
+routes! {
+    GET "/henlo" => |_| "hiya";
+}
+
+fn main() -> Result<(), minreq::Error> {
+    let expected = "hiya";
+
+    let (mut addr, thread) = run_once!();
+    addr.push_str("henlo");
+
+    let resp = minreq::get(addr).send()?;
+    let resp = resp.as_str()?;
+    // WARN: to prevent resource leaks join the thread after sending the request
+    _ = thread.join();
+
+    println!("Response: \"{}\"", resp);
+    assert_eq!(resp, expected);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,8 @@ pub mod session;
 
 pub use {
     bundler::bundle_assets, cache::TypeCache, error::Error, method::Method, request::Request,
-    responder::Responder, response::Response, router::Router, server::run,
+    responder::Responder, response::Response, router::Router, server::run, server::Server,
+    server::MAX_CONNECTIONS,
 };
 
 /// Convenience Result that returns `vial::Error`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,8 +234,8 @@ pub mod session;
 
 pub use {
     bundler::bundle_assets, cache::TypeCache, error::Error, method::Method, request::Request,
-    responder::Responder, response::Response, router::Router, server::run, server::Server,
-    server::MAX_CONNECTIONS,
+    responder::Responder, response::Response, router::Router, server::run, server::run_once,
+    server::Server, server::MAX_CONNECTIONS,
 };
 
 /// Convenience Result that returns `vial::Error`.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -173,7 +173,7 @@ macro_rules! run_once {
         vial::run_once!($addr, self)
     }};
     ($($module:ident),+) => {{
-        vial::run!("127.0.0.1:0", $($module),+)
+        vial::run_once!("127.0.0.1:0", $($module),+)
     }};
     ($addr:expr, $($module:ident),+) => {{
         vial::setup!();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -112,6 +112,77 @@ macro_rules! run_with_banner {
     }};
 }
 
+/// `vial::run_once!`, similarly to `vial::run!`, starts a server.
+/// However, this server is started in a *separate thread* and only
+/// listens for one request then shuts down. This server is by default
+/// bound to an [ephemeral port](https://en.wikipedia.org/wiki/Ephemeral_port).
+/// This macro is meant to facilitate easy HTTP
+/// [mocking](https://en.wikipedia.org/wiki/Mock_object).
+///
+/// To be able to know what port is bound to the server instance the
+/// macro returns a `String` containing the IP and port combination with
+/// "http://" prepended (to allow for easier use) and ending with a '/',
+/// for example: `http://127.0.0.1:58231/`.
+///
+/// The macro also returns a [handle](std::thread::JoinHandle) to the thread that
+/// is spawned so it can be properly joined by the user. See [spawn](std::thread::spawn)
+/// for an explanation on that.
+///
+/// Note that even if multiple routes are defined, only one request is processed before the server
+/// shuts down.
+///
+/// `run_once!` accepts the same parameters as run. Below is an example of using `vial::run_once!`.
+///
+/// ```no_run
+/// use minreq;
+///
+/// mod wiki {
+///     vial::routes! {
+///         GET "/wiki" => |_| Response::from_file("wiki.html");
+///     }
+/// }
+///
+/// mod blog {
+///     vial::routes! {
+///         GET "/blog" => show_blog;
+///         // etc...
+///     }
+///
+///     fn show_blog(req: vial::Request) -> String {
+///         // ...
+///         "blog".to_string()
+///     }
+/// }
+///
+/// fn main() {
+///     let (mut addr, thread) = vial::run_once!(wiki, blog);
+///     addr.push_str("blog");
+///     let resp = minreq::get(addr).send().unwrap();
+///     let _ = thread.join();
+///     println!("Response: {}", resp.as_str().unwrap());
+/// }
+/// ```
+///
+///
+#[macro_export]
+macro_rules! run_once {
+    () => {
+        vial::run_once!("127.0.0.1:0")
+    };
+    ($addr:expr) => {{
+        vial::run_once!($addr, self)
+    }};
+    ($($module:ident),+) => {{
+        vial::run!("127.0.0.1:0", $($module),+)
+    }};
+    ($addr:expr, $($module:ident),+) => {{
+        vial::setup!();
+        let mut router = ::vial::Router::new();
+        $($module::vial_add_to_router(&mut router);)+
+        vial::run_once($addr, router).unwrap()
+    }};
+}
+
 /// Gives Vial a state object to manage globally. You can access it
 /// by calling
 /// [`request.state::<YourStruct>()`](struct.Request.html#method.state)

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,64 +2,118 @@ use {
     crate::{asset, Request, Response, Result, Router},
     std::{
         io::Write,
-        net::{TcpListener, TcpStream, ToSocketAddrs},
+        net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs},
         sync::{Arc, Mutex},
     },
     threadpool::ThreadPool,
 };
 
-const MAX_CONNECTIONS: usize = 10;
+/// Default max number of simultaneous connections.
+pub const MAX_CONNECTIONS: usize = 10;
 
 /// Starts a new Vial server. Should always be invoked via the
 /// [`vial::run!()`](macro.run.html) macro, since there is some setup
 /// that needs to happen.
 #[doc(hidden)]
 pub fn run<T: ToSocketAddrs>(addr: T, router: Router, banner: Option<&str>) -> Result<()> {
-    let pool = ThreadPool::new(MAX_CONNECTIONS);
-    let listener = TcpListener::bind(&addr)?;
-    let addr = listener.local_addr()?;
-    let server = Arc::new(Server::new(router));
-
-    #[cfg(feature = "state")]
-    eprintln!("! vial feature `state` is now built-in. You can safely remove it.");
-
-    if let Some(banner) = banner {
-        if !banner.is_empty() {
-            println!("{}", banner.replace("{}", &format!("http://{}", addr)));
-        }
-    } else {
-        println!("~ vial running at http://{}", addr);
-    }
-
-    for stream in listener.incoming() {
-        let server = server.clone();
-        let stream = stream?;
-        pool.execute(move || {
-            if let Err(e) = server.handle_request(stream) {
-                eprintln!("!! {}", e);
-            }
-        });
-    }
-
+    let mut addr = addr.to_socket_addrs()?;
+    let addr = addr.next().unwrap();
+    let mut server = Server::new(router, addr, MAX_CONNECTIONS, banner);
+    server.run();
     Ok(())
 }
 
-struct Server {
-    router: Router,
+/// A Vial server instance. Has its own threadpool to handle incoming connections.
+pub struct Server<'s> {
+    router: Arc<Router>,
+    listener: TcpListener,
+    pool: ThreadPool,
+    banner: Option<&'s str>,
 }
 
-impl Server {
-    pub fn new(router: Router) -> Server {
-        Server { router }
+impl<'s> Server<'s> {
+    /// Creates a new Vial server instance. This immediately binds the given address, but does not
+    /// start accepting incoming traffic until `run` is called.
+    pub fn new(
+        router: Router,
+        addr: SocketAddr,
+        num_threads: usize,
+        banner: Option<&'s str>,
+    ) -> Server {
+        let listener = TcpListener::bind(&addr)
+            .expect(&format!("unable to bind to addr: {}", addr.to_string()));
+        Server {
+            router: Arc::new(router),
+            listener,
+            pool: ThreadPool::new(num_threads),
+            banner,
+        }
     }
 
-    fn handle_request(&self, stream: TcpStream) -> Result<()> {
+    /// Returns the local address the server is bound to.
+    pub fn addr(&self) -> SocketAddr {
+        // SAFETY: Safe, since the listener is already bound at this point
+        self.listener.local_addr().unwrap()
+    }
+
+    /// Prints the banner info to stdout.
+    fn print_banner(&self) {
+        #[cfg(feature = "state")]
+        eprintln!("! vial feature `state` is now built-in. You can safely remove it.");
+
+        if let Some(banner) = self.banner {
+            if !banner.is_empty() {
+                println!(
+                    "{}",
+                    banner.replace("{}", &format!("http://{}", self.addr()))
+                );
+            }
+        } else {
+            println!("~ vial running at http://{}", self.addr());
+        }
+    }
+
+    /// Runs this server instance indefinitely.
+    pub fn run(&mut self) {
+        self.print_banner();
+
+        for stream in self.listener.incoming() {
+            let router = self.router.clone();
+            match stream {
+                Ok(stream) => {
+                    self.pool.execute(move || {
+                        if let Err(e) = Self::handle_request(stream, router) {
+                            eprintln!("!! {}", e);
+                        }
+                    });
+                }
+                Err(_) => eprintln!("!! connection failed"),
+            };
+        }
+    }
+
+    /// Runs the server instance for one incoming request. Useful for mock testing.
+    pub fn run_once(&mut self) {
+        self.print_banner();
+
+        match self.listener.accept() {
+            Ok((stream, _)) => {
+                if let Err(e) = Self::handle_request(stream, self.router.clone()) {
+                    eprintln!("!! {}", e);
+                }
+            }
+
+            Err(_) => eprintln!("!! connection failed"),
+        };
+    }
+
+    fn handle_request(stream: TcpStream, router: Arc<Router>) -> Result<()> {
         let reader = stream.try_clone()?;
         let req = Request::from_reader(reader)?;
-        self.write_response(stream, req)
+        Self::write_response(stream, req, router)
     }
 
-    fn write_response(&self, stream: TcpStream, req: Request) -> Result<()> {
+    fn write_response(stream: TcpStream, req: Request, router: Arc<Router>) -> Result<()> {
         let panic_writer = Arc::new(Mutex::new(stream.try_clone()?));
         std::panic::set_hook(Box::new(move |info| {
             let mut res: Vec<u8> = vec![];
@@ -75,7 +129,7 @@ impl Server {
 
         let method = req.method().to_string();
         let path = req.path().to_string();
-        let response = self.build_response(req);
+        let response = Self::build_response(req, router);
 
         println!("{} {} {}", method, response.code(), path);
         if response.code() == 500 {
@@ -85,7 +139,7 @@ impl Server {
         response.write(stream)
     }
 
-    fn build_response(&self, mut req: Request) -> Response {
+    fn build_response(mut req: Request, router: Arc<Router>) -> Response {
         if asset::exists(req.path()) {
             if let Some(req_etag) = req.header("If-None-Match") {
                 if req_etag == asset::etag(req.path()).as_ref() {
@@ -96,7 +150,7 @@ impl Server {
             } else {
                 Response::from_asset(req.path())
             }
-        } else if let Some(action) = self.router.action_for(&mut req) {
+        } else if let Some(action) = router.action_for(&mut req) {
             action(req)
         } else {
             Response::from(404)

--- a/tests/mock_test.rs
+++ b/tests/mock_test.rs
@@ -1,48 +1,46 @@
 #[cfg(feature = "mock")]
-use {
-    minreq::{Method, Request},
-    std::{
-        net::{Ipv4Addr, SocketAddrV4},
-        thread,
-    },
-    vial::{Response, Router, Server},
-};
+mod mock {
+    use {
+        minreq::{Method, Request},
+        std::{
+            net::{Ipv4Addr, SocketAddrV4},
+            thread,
+        },
+        vial::{Response, Router, Server},
+    };
 
-#[cfg(feature = "mock")]
-fn make_request(router: Router, method: Method, url: &str) -> minreq::Response {
-    let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
-    let mut server = Server::new(router, addr.into(), 1, None);
-    let request_addr = format!("http://{}{}", server.addr(), url);
-    let request = Request::new(method, request_addr);
-    thread::spawn(move || {
-        server.run_once();
-    });
-    let resp = request.send().unwrap();
+    fn make_request(router: Router, method: Method, url: &str) -> minreq::Response {
+        let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
+        let mut server = Server::new(router, addr.into(), 1, None);
+        let request_addr = format!("http://{}{}", server.addr(), url);
+        let request = Request::new(method, request_addr);
+        thread::spawn(move || {
+            server.run_once();
+        });
+        let resp = request.send().unwrap();
 
-    resp
-}
+        resp
+    }
 
-#[cfg(feature = "mock")]
-fn string_body(_: vial::Request) -> Response {
-    "Hello, World!".into()
-}
+    fn string_body(_: vial::Request) -> Response {
+        "Hello, World!".into()
+    }
 
-#[test]
-#[cfg(feature = "mock")]
-fn mock_get() {
-    let mut router = Router::new();
-    router.insert("GET", "/get", string_body);
-    let resp = make_request(router, Method::Get, "/get");
-    assert_eq!(resp.status_code, 200);
-    assert_eq!(resp.as_str().unwrap(), "Hello, World!")
-}
+    #[test]
+    fn get() {
+        let mut router = Router::new();
+        router.insert("GET", "/get", string_body);
+        let resp = make_request(router, Method::Get, "/get");
+        assert_eq!(resp.status_code, 200);
+        assert_eq!(resp.as_str().unwrap(), "Hello, World!")
+    }
 
-#[test]
-#[cfg(feature = "mock")]
-fn mock_post() {
-    let mut router = Router::new();
-    router.insert("POST", "/post", string_body);
-    let resp = make_request(router, Method::Post, "/post");
-    assert_eq!(resp.status_code, 200);
-    assert_eq!(resp.as_str().unwrap(), "Hello, World!")
+    #[test]
+    fn post() {
+        let mut router = Router::new();
+        router.insert("POST", "/post", string_body);
+        let resp = make_request(router, Method::Post, "/post");
+        assert_eq!(resp.status_code, 200);
+        assert_eq!(resp.as_str().unwrap(), "Hello, World!")
+    }
 }

--- a/tests/mock_test.rs
+++ b/tests/mock_test.rs
@@ -1,0 +1,48 @@
+#[cfg(feature = "mock")]
+use {
+    minreq::{Method, Request},
+    std::{
+        net::{Ipv4Addr, SocketAddrV4},
+        thread,
+    },
+    vial::{Response, Router, Server},
+};
+
+#[cfg(feature = "mock")]
+fn make_request(router: Router, method: Method, url: &str) -> minreq::Response {
+    let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
+    let mut server = Server::new(router, addr.into(), 1, None);
+    let request_addr = format!("http://{}{}", server.addr(), url);
+    let request = Request::new(method, request_addr);
+    thread::spawn(move || {
+        server.run_once();
+    });
+    let resp = request.send().unwrap();
+
+    resp
+}
+
+#[cfg(feature = "mock")]
+fn string_body(_: vial::Request) -> Response {
+    "Hello, World!".into()
+}
+
+#[test]
+#[cfg(feature = "mock")]
+fn mock_get() {
+    let mut router = Router::new();
+    router.insert("GET", "/get", string_body);
+    let resp = make_request(router, Method::Get, "/get");
+    assert_eq!(resp.status_code, 200);
+    assert_eq!(resp.as_str().unwrap(), "Hello, World!")
+}
+
+#[test]
+#[cfg(feature = "mock")]
+fn mock_post() {
+    let mut router = Router::new();
+    router.insert("POST", "/post", string_body);
+    let resp = make_request(router, Method::Post, "/post");
+    assert_eq!(resp.status_code, 200);
+    assert_eq!(resp.as_str().unwrap(), "Hello, World!")
+}

--- a/tests/mock_test.rs
+++ b/tests/mock_test.rs
@@ -1,46 +1,43 @@
-#[cfg(feature = "mock")]
-mod mock {
-    use {
-        minreq::{Method, Request},
-        std::{
-            net::{Ipv4Addr, SocketAddrV4},
-            thread,
-        },
-        vial::{Response, Router, Server},
-    };
+use {
+    minreq::{Method, Request},
+    std::{
+        net::{Ipv4Addr, SocketAddrV4},
+        thread,
+    },
+    vial::{Response, Router, Server},
+};
 
-    fn make_request(router: Router, method: Method, url: &str) -> minreq::Response {
-        let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
-        let mut server = Server::new(router, addr.into(), 1, None);
-        let request_addr = format!("http://{}{}", server.addr(), url);
-        let request = Request::new(method, request_addr);
-        thread::spawn(move || {
-            server.run_once();
-        });
-        let resp = request.send().unwrap();
+fn make_request(router: Router, method: Method, url: &str) -> minreq::Response {
+    let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
+    let mut server = Server::new(router, addr.into(), 1, None);
+    let request_addr = format!("http://{}{}", server.addr(), url);
+    let request = Request::new(method, request_addr);
+    thread::spawn(move || {
+        server.run_once();
+    });
+    let resp = request.send().unwrap();
 
-        resp
-    }
+    resp
+}
 
-    fn string_body(_: vial::Request) -> Response {
-        "Hello, World!".into()
-    }
+fn string_body(_: vial::Request) -> Response {
+    "Hello, World!".into()
+}
 
-    #[test]
-    fn get() {
-        let mut router = Router::new();
-        router.insert("GET", "/get", string_body);
-        let resp = make_request(router, Method::Get, "/get");
-        assert_eq!(resp.status_code, 200);
-        assert_eq!(resp.as_str().unwrap(), "Hello, World!")
-    }
+#[test]
+fn mock_get() {
+    let mut router = Router::new();
+    router.insert("GET", "/get", string_body);
+    let resp = make_request(router, Method::Get, "/get");
+    assert_eq!(resp.status_code, 200);
+    assert_eq!(resp.as_str().unwrap(), "Hello, World!")
+}
 
-    #[test]
-    fn post() {
-        let mut router = Router::new();
-        router.insert("POST", "/post", string_body);
-        let resp = make_request(router, Method::Post, "/post");
-        assert_eq!(resp.status_code, 200);
-        assert_eq!(resp.as_str().unwrap(), "Hello, World!")
-    }
+#[test]
+fn mock_post() {
+    let mut router = Router::new();
+    router.insert("POST", "/post", string_body);
+    let resp = make_request(router, Method::Post, "/post");
+    assert_eq!(resp.status_code, 200);
+    assert_eq!(resp.as_str().unwrap(), "Hello, World!")
 }


### PR DESCRIPTION
Hiya!

`vial` is so small and handy I've thought about using it as a dev dependency for local integration tests, so called "HTTP mocking", for a while. It would be an excellent fit compared to existing alternatives. As in most cases you just need to serve a simple page that returns something you expect and that is exactly what vial does.

This PR mostly concerns how `server.rs` is structured and adding an optional `mock` feature flag. I mostly just concentrated everything under the `Server` struct instead of in the `run` function and made a bunch of stuff public.

I ran into some race-conditions when jury-rigging this a while back, but these may have been fixed when you changed how state's are managed as I've not run into it yet on the latest release. Might need some more testing.

I've left this as a draft since some neat examples of the "mocking" use-case may want to be written and so you can also go through it all to ensure I am not doing something completely insane.

(Note: The tests in `mock_test.rs` is behind the `mock` feature flag)